### PR TITLE
No reason to check for existence with which.sync

### DIFF
--- a/linux.js
+++ b/linux.js
@@ -7,9 +7,7 @@ function getBin(commands) {
 		return null;
 	}
 	for (let i = 0; i < commands.length; i++) {
-		if (which.sync(commands[i])) {
-			return which.sync(commands[i], {nothrow: true})
-		}
+		return which.sync(commands[i], {nothrow: true});
 	}
 
 	return null;


### PR DESCRIPTION
...if calling which.sync with "nothrow" set. This causes an error when not found; removing that check fixes it, and returns a null value as expected.