### PR TITLE
feat(thorium): add remaining os support

### DIFF
--- a/macos.js
+++ b/macos.js
@@ -29,10 +29,13 @@ function getEdge() {
 	return testPath("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge");
 }
 
+function getThorium() {
+	return testPath("/Applications/Thorium.app/Contents/MacOS/Thorium");
+}
 
 function getChromium() {
 	//There is no chromium default install path for windows
-	return getChrome() || getEdge();
+	return getChrome() || getEdge() || getThorium();
 }
 
 function getFirefox() {

--- a/macos.js
+++ b/macos.js
@@ -43,4 +43,4 @@ function getFirefox() {
 }
 
 
-module.exports = { getChrome, getEdge, getChromium, getFirefox };
+module.exports = { getChrome, getEdge, getThorium, getChromium, getFirefox };

--- a/windows.js
+++ b/windows.js
@@ -30,6 +30,10 @@ function getChrome() {
 	return getPath("\\Google\\Chrome\\Application\\chrome.exe");
 }
 
+function getThorium() {
+	return getPath("\\Thorium\\Application\\thorium.exe");
+}
+
 function getEdge() {
 	//In fact it only is in Program Files (x86)
 	return getPath("\\Microsoft\\Edge\\Application\\msedge.exe");
@@ -37,7 +41,7 @@ function getEdge() {
 
 function getChromium() {
 	//There is no chromium default install path for windows
-	return getChrome() || getEdge();
+	return getChrome() || getEdge() || getThorium();
 }
 
 

--- a/windows.js
+++ b/windows.js
@@ -50,4 +50,4 @@ function getFirefox() {
 }
 
 
-module.exports = {getChrome, getEdge, getChromium, getFirefox};
+module.exports = {getChrome, getEdge, getThorium, getChromium, getFirefox};


### PR DESCRIPTION
# I'm back with the milk 🥛

- Adds detecting Thorium on ABSOLUTELY PROPRIETARY MICROSOFT WINDOWS
- Adds detecting Thorium on Windows fearing operating System big mac os

Closes #2 

![image](https://github.com/albertopasqualetto/browser-paths/assets/117921904/74d0008a-9965-4c52-93e2-c834fe1d12b9)
