### PR TITLE
Fix Linux pathing issues.

### DIFF
--- a/linux.js
+++ b/linux.js
@@ -1,13 +1,15 @@
 var which = require('which');
 
-
 function getBin(commands) {
 	// Don't run these checks if not on linux
 	if (process.platform !== 'linux') {
 		return null;
 	}
+	// Check each command separately
+	let path = null;
 	for (let i = 0; i < commands.length; i++) {
-		return which.sync(commands[i], {nothrow: true});
+		path = which.sync(commands[i], {nothrow: true});
+		if (path) return path;
 	}
 
 	return null;


### PR DESCRIPTION
The old code would just return the very first result of the array, regardless of what it was (null or a string). This corrects it and returns the first option that results in a non-null value.